### PR TITLE
Add longText to columns

### DIFF
--- a/database/migrations/5_change_columns_to_long_text.php.stub
+++ b/database/migrations/5_change_columns_to_long_text.php.stub
@@ -9,8 +9,8 @@ return new class extends Migration
     public function up()
     {
         Schema::table(config('mails.database.tables.mails'), function (Blueprint $table) {
-            $table->longText('html')->change();
-            $table->longText('text')->change();
+            $table->longText('html')->nullable()->change();
+            $table->longText('text')->nullable()->change();
         });
         
     }
@@ -18,8 +18,8 @@ return new class extends Migration
     public function down()
     {
         Schema::table(config('mails.database.tables.mails'), function (Blueprint $table) {
-            $table->text('html')->change();
-            $table->text('text')->change();
+            $table->text('html')->nullable()->change();
+            $table->text('text')->nullable()->change();
         });
     }
 };

--- a/database/migrations/5_change_columns_to_long_text.php.stub
+++ b/database/migrations/5_change_columns_to_long_text.php.stub
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table(config('mails.database.tables.mails'), function (Blueprint $table) {
+            $table->longText('html')->change();
+            $table->longText('text')->change();
+        });
+        
+    }
+
+    public function down()
+    {
+        Schema::table(config('mails.database.tables.mails'), function (Blueprint $table) {
+            $table->text('html')->change();
+            $table->text('text')->change();
+        });
+    }
+};


### PR DESCRIPTION
This pull request introduces a migration to update the database schema by changing the column types for `html` and `text` fields in the `mails` table to `longText`. This ensures these fields can store larger amounts of data.

Database schema changes:

* [`database/migrations/5_change_columns_to_long_text.php.stub`](diffhunk://#diff-a2f3d2d76af6acc048c942ae44ebc9c350fe09dc83a570d62cd0266dc7cd93b1R1-R25): Added a migration to change the `html` and `text` columns in the `mails` table from `text` to `longText`, with a corresponding `down` method to revert the changes if needed.