### PR TITLE
fix: missing resend event

### DIFF
--- a/src/Drivers/MailDriver.php
+++ b/src/Drivers/MailDriver.php
@@ -2,6 +2,7 @@
 
 namespace Backstage\Mails\Drivers;
 
+use Backstage\Mails\Exceptions\LaravelMailException;
 use Exception;
 use Illuminate\Support\Str;
 use Backstage\Mails\Models\Mail;
@@ -51,12 +52,13 @@ abstract class MailDriver
     public function getEventFromPayload(array $payload): string
     {
         foreach ($this->eventMapping() as $event => $mapping) {
+
             if (collect($mapping)->every(fn ($value, $key) => data_get($payload, $key) === $value)) {
                 return $event;
             }
         }
 
-        throw new Exception('Unknown event type');
+        throw LaravelMailException::unknownEventType();
     }
 
     public function logMailEvent($payload): void

--- a/src/Drivers/ResendDriver.php
+++ b/src/Drivers/ResendDriver.php
@@ -34,6 +34,7 @@ class ResendDriver extends MailDriver implements MailDriverContract
     public function eventMapping(): array
     {
         return [
+            EventType::ACCEPTED->value => ['type' => 'email.sent'],
             EventType::CLICKED->value => ['type' => 'email.clicked'],
             EventType::COMPLAINED->value => ['type' => 'email.complained'],
             EventType::DELIVERED->value => ['type' => 'email.delivered'],

--- a/src/Exceptions/LaravelMailException.php
+++ b/src/Exceptions/LaravelMailException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Backstage\Mails\Exceptions;
+
+use Exception;
+
+class LaravelMailException extends Exception
+{
+    public static function unknownEventType(): self
+    {
+        return new self("Unknown event type. Please check the event mapping in your mail driver.");
+    }
+}


### PR DESCRIPTION
This pull request introduces improved error handling for unknown mail event types and adds support for a new event mapping in the `ResendDriver`. The most significant changes include the addition of a custom exception class for mail errors and an update to the event mapping logic.

**Error handling improvements:**

* Added a new exception class `LaravelMailException` in `src/Exceptions/LaravelMailException.php` to provide more descriptive error messages for unknown event types.
* Updated `MailDriver::getEventFromPayload` to throw the new `LaravelMailException::unknownEventType()` instead of a generic `Exception`, improving clarity and maintainability. 

**Event mapping update:**

* Added support for the `ACCEPTED` event type in the `ResendDriver::eventMapping`, mapping it to `email.sent`.